### PR TITLE
Drones can pull stuff

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -37,7 +37,7 @@ var/list/mob_hat_cache = list()
 	integrated_light_power = 3
 	local_transmit = 1
 
-	can_pull_size = ITEMSIZE_NORMAL
+	can_pull_size = ITEMSIZE_HUGE //Magnets. They use magnets. Let's go with that.
 	can_pull_mobs = MOB_PULL_SMALLER
 
 	mob_bump_flag = SIMPLE_ANIMAL


### PR DESCRIPTION
Tiny little spidery robots now possess the strength of a thousand men. Or, well, at least the strength of one man. Or magnets, or something like that. Anyways, they can pull bigger stuff now!

Amusingly, they could pull stuff before, but it had to be kinda small. You know what's kinda small? Bombs. The Nuke Disk. The contents of the armory.

But not canisters. Oh, no, canisters are too griefy

Fixes #159